### PR TITLE
feat(libprecious): allow for configurable tar directory

### DIFF
--- a/packages/libprecious/index.js
+++ b/packages/libprecious/index.js
@@ -132,8 +132,9 @@ class MyPrecious {
 
   getTarballPath (spec, dep) {
     // TODO - this is obviously not good enough, but it's good for a demo
+    const dir = this.config.get('vendor-directory') || 'archived-packages'
     const filename = `${spec.name}-${dep.version}.tgz`
-    return path.join(this.prefix, 'archived-packages', filename)
+    return path.join(this.prefix, dir, filename)
   }
 
   updateLockfile (tree) {


### PR DESCRIPTION
This uses the config variable `vendor-directory` to drive where the tars are saved to.
Defaults to `archived-packages`

Happy to change some/any of this - raising this PR more as a proposal than a concrete solution.